### PR TITLE
fix: on finish hook

### DIFF
--- a/src/query/service/src/interpreters/mod.rs
+++ b/src/query/service/src/interpreters/mod.rs
@@ -117,7 +117,7 @@ pub use interpreter_call::CallInterpreter;
 pub use interpreter_cluster_key_alter::AlterTableClusterKeyInterpreter;
 pub use interpreter_cluster_key_drop::DropTableClusterKeyInterpreter;
 pub use interpreter_clustering_history::InterpreterClusteringHistory;
-pub use interpreter_copy::append_data_and_set_finish;
+pub use interpreter_copy::chain_append_data_pipeline;
 pub use interpreter_copy::PlanParam;
 pub use interpreter_data_mask_create::CreateDataMaskInterpreter;
 pub use interpreter_data_mask_desc::DescDataMaskInterpreter;

--- a/src/query/service/src/pipelines/pipeline_builder.rs
+++ b/src/query/service/src/pipelines/pipeline_builder.rs
@@ -14,7 +14,6 @@
 
 use std::convert::TryFrom;
 use std::sync::Arc;
-use std::time::Instant;
 
 use async_channel::Receiver;
 use common_catalog::table::AppendMode;
@@ -89,7 +88,7 @@ use super::processors::transforms::WindowFunctionInfo;
 use super::processors::TransformExpandGroupingSets;
 use crate::api::DefaultExchangeInjector;
 use crate::api::ExchangeInjector;
-use crate::interpreters::append_data_and_set_finish;
+use crate::interpreters::chain_append_data_pipeline;
 use crate::interpreters::fill_missing_columns;
 use crate::interpreters::PlanParam;
 use crate::pipelines::processors::transforms::build_partition_bucket;
@@ -222,17 +221,15 @@ impl PipelineBuilder {
         stage_table.set_block_thresholds(distributed_plan.thresholds);
         let ctx = self.ctx.clone();
         let table_ctx: Arc<dyn TableContext> = ctx.clone();
-        let start = Instant::now();
         stage_table.read_data(table_ctx, &distributed_plan.source, &mut self.main_pipeline)?;
         // append data
-        append_data_and_set_finish(
+        chain_append_data_pipeline(
             &mut self.main_pipeline,
             distributed_plan.required_source_schema.clone(),
             PlanParam::DistributedCopyIntoTable(distributed_plan.clone()),
             ctx,
             to_table,
             distributed_plan.files.clone(),
-            start,
             false,
         )?;
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix on finish hook duplicated issue. only hook on-finish at the node that drives the execution of distributed copy into

Closes #issue
